### PR TITLE
feat: add GitHub Pages deployment workflow

### DIFF
--- a/{{cookiecutter.protocol_name}}/.github/workflows/deploy-gh-pages.yml
+++ b/{{cookiecutter.protocol_name}}/.github/workflows/deploy-gh-pages.yml
@@ -19,7 +19,7 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/{{cookiecutter.protocol_name}}/.github/workflows/deploy-gh-pages.yml
+++ b/{{cookiecutter.protocol_name}}/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,103 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or commit SHA to deploy'
+        required: false
+        default: 'main'
+        type: string
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: {% raw %}${{ github.event.inputs.ref || github.ref }}{% endraw %}
+
+      - name: Get deployment ref
+        id: get-ref
+        run: |
+          if [ "{% raw %}${{ github.event_name }}{% endraw %}" = "workflow_dispatch" ] && [ -n "{% raw %}${{ github.event.inputs.ref }}{% endraw %}" ]; then
+            echo "deploy_ref={% raw %}${{ github.event.inputs.ref }}{% endraw %}" >> $GITHUB_OUTPUT
+          elif [ -n "{% raw %}${{ github.ref_name }}{% endraw %}" ]; then
+            echo "deploy_ref={% raw %}${{ github.ref_name }}{% endraw %}" >> $GITHUB_OUTPUT
+          else
+            echo "deploy_ref=main" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Clone reproschema-ui
+        run: |
+          git clone https://github.com/ReproNim/reproschema-ui.git
+          cd reproschema-ui
+          git checkout master
+
+      - name: Build reproschema-ui
+        run: |
+          cd reproschema-ui
+          npm install
+          npm run build
+
+      - name: Copy protocol to reproschema-ui
+        run: |
+          # Copy the entire protocol directory to the reproschema-ui public folder
+          cp -r ./{{cookiecutter.__protocol_slug}} reproschema-ui/dist/
+          cp -r ./activities reproschema-ui/dist/
+          
+          # Update the config to point to our protocol
+          cat > reproschema-ui/dist/config.js << 'EOF'
+          module.exports = {
+            /* eslint-disable */
+            githubSrc: 'https://raw.githubusercontent.com/{{cookiecutter.github_org}}/{{cookiecutter.protocol_name}}/{% raw %}${{ steps.get-ref.outputs.deploy_ref }}{% endraw %}/{{cookiecutter.__protocol_slug}}/{{cookiecutter.__protocol_slug}}_schema',
+            banner: 'This protocol is deployed from {{cookiecutter.github_org}}/{{cookiecutter.protocol_name}} (ref: {% raw %}${{ steps.get-ref.outputs.deploy_ref }}{% endraw %})',
+            startButton: 'Start',
+            assetsPublicPath: '/',
+            backendServer: null,
+            showHelp: true,
+            contact: '{{cookiecutter.email}}',
+            emailSubject: 'Help with {{cookiecutter.protocol_name}}',
+            logoSrc: '{{cookiecutter.__protocol_slug}}/about_the_study.svg',
+            auth: {
+              on: false,
+            },
+          };
+          EOF
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'reproschema-ui/dist'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: {% raw %}${{ steps.deployment.outputs.page_url }}{% endraw %}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/{{cookiecutter.protocol_name}}/.github/workflows/deploy-gh-pages.yml
+++ b/{{cookiecutter.protocol_name}}/.github/workflows/deploy-gh-pages.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build reproschema-ui
         run: |
           cd reproschema-ui
-          npm install
+          npm ci
           npm run build
 
       - name: Copy protocol to reproschema-ui

--- a/{{cookiecutter.protocol_name}}/.github/workflows/deploy-gh-pages.yml
+++ b/{{cookiecutter.protocol_name}}/.github/workflows/deploy-gh-pages.yml
@@ -50,7 +50,8 @@ jobs:
         run: |
           git clone https://github.com/ReproNim/reproschema-ui.git
           cd reproschema-ui
-          git checkout master
+          # Pin to specific commit for reproducible builds
+          git checkout 9f7b6b961cdcb516531bbbf1bf1b74648089d04a
 
       - name: Build reproschema-ui
         run: |

--- a/{{cookiecutter.protocol_name}}/.github/workflows/deploy-gh-pages.yml
+++ b/{{cookiecutter.protocol_name}}/.github/workflows/deploy-gh-pages.yml
@@ -69,8 +69,8 @@ jobs:
           cat > reproschema-ui/dist/config.js << 'EOF'
           module.exports = {
             /* eslint-disable */
-            githubSrc: 'https://raw.githubusercontent.com/{{cookiecutter.github_org}}/{{cookiecutter.protocol_name}}/{% raw %}${{ steps.get-ref.outputs.deploy_ref }}{% endraw %}/{{cookiecutter.__protocol_slug}}/{{cookiecutter.__protocol_slug}}_schema',
-            banner: 'This protocol is deployed from {{cookiecutter.github_org}}/{{cookiecutter.protocol_name}} (ref: {% raw %}${{ steps.get-ref.outputs.deploy_ref }}{% endraw %})',
+            githubSrc: 'https://raw.githubusercontent.com/{{cookiecutter.github_org}}/{{cookiecutter.protocol_name|slugify}}/{% raw %}${{ steps.get-ref.outputs.deploy_ref }}{% endraw %}/{{cookiecutter.__protocol_slug}}/{{cookiecutter.__protocol_slug}}_schema',
+            banner: 'This protocol is deployed from {{cookiecutter.github_org}}/{{cookiecutter.protocol_name|slugify}} (ref: {% raw %}${{ steps.get-ref.outputs.deploy_ref }}{% endraw %})',
             startButton: 'Start',
             assetsPublicPath: '/',
             backendServer: null,

--- a/{{cookiecutter.protocol_name}}/README.md
+++ b/{{cookiecutter.protocol_name}}/README.md
@@ -4,7 +4,33 @@
 
 ## Website
 
-[https://{{cookiecutter.github_org}}.github.io/{{cookiecutter.protocol_name}}](https://{{cookiecutter.github_org}}.github.io/{{cookiecutter.protocol_name}})
+[https://{{cookiecutter.github_org}}.github.io/{{cookiecutter.protocol_name|slugify}}](https://{{cookiecutter.github_org}}.github.io/{{cookiecutter.protocol_name|slugify}})
+
+## Deployment to GitHub Pages
+
+This repository includes automatic deployment to GitHub Pages. Follow these steps to enable it:
+
+1. **Enable GitHub Pages in your repository:**
+   - Go to Settings → Pages
+   - Under "Source", select "GitHub Actions"
+   - Click Save
+
+2. **The deployment will trigger automatically when:**
+   - You push to the `main` branch
+   - You push a tag starting with `v` (e.g., `v1.0.0`)
+   - You manually trigger the workflow from the Actions tab
+
+3. **Deploy a specific version:**
+   - Go to the Actions tab
+   - Select "Deploy to GitHub Pages"
+   - Click "Run workflow"
+   - Enter the branch, tag, or commit SHA you want to deploy
+   - Click "Run workflow"
+
+4. **Access your deployed protocol:**
+   - Once deployed, visit: `https://{{cookiecutter.github_org}}.github.io/{{cookiecutter.protocol_name|slugify}}`
+   - The deployment typically takes 2-5 minutes
+   - The deployed version is shown in the banner
 
 ## Repository Structure
 


### PR DESCRIPTION
## Summary

This PR adds automatic GitHub Pages deployment functionality to the reproschema-protocol-cookiecutter template. Generated protocols can now be easily deployed as interactive web applications using reproschema-ui.

## Features Added

### 1. GitHub Actions Workflow
- New workflow file: `.github/workflows/deploy-gh-pages.yml`
- Automatic deployment on:
  - Push to `main` branch
  - Version tags (`v*`)
  - Manual trigger with specific ref (branch/tag/commit)
- Builds and configures reproschema-ui to serve the protocol
- Shows deployed version in the banner for transparency

### 2. Documentation Updates
- Comprehensive deployment instructions in README
- Step-by-step guide for enabling GitHub Pages
- Instructions for both automatic and manual deployment
- Fixed URL generation using slugified protocol names

## Technical Details

- Uses Jinja2 `{% raw %}` tags to properly escape GitHub Actions expressions
- Minimal permissions for security (contents: read, pages: write, id-token: write)
- Concurrency control to prevent deployment conflicts
- Supports deployment of specific versions/commits for testing

## Testing

- [x] YAML syntax validated
- [x] Cookiecutter template generation tested
- [x] Variable substitution verified
- [x] Security best practices reviewed by QA agent
- [x] URL encoding issue fixed with slugify filter

## Related Issues

This PR builds on top of #10 (which has been merged) and provides the deployment capability requested in the original discussion.

## Next Steps

Users can now:
1. Generate a protocol using the cookiecutter
2. Push to GitHub
3. Enable GitHub Pages (Settings → Pages → Source: GitHub Actions)
4. Protocol automatically deploys to `https://<org>.github.io/<protocol-name>`